### PR TITLE
feat: remove HyperScript from features, update version to 0.2.3, and prep for PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ This will generate a minimal, production-ready Django API backend with all the a
 - HTMX for dynamic HTML updates
 - AlpineJS for lightweight JavaScript interactions
 - Django-allauth for authentication
-- HyperScript for easy DOM manipulation
 - TailwindCSS and DaisyUI for styling
 - Docker support (optional)
 - PostgreSQL database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modern-django-starter"
-version = "0.2.2"
+version = "0.2.3"
 description = "A CLI tool for generating Django 5.x projects with HTMX, AlpineJS, and more"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
- Removed "HyperScript for easy DOM manipulation" from the README features list (not included in the stack)
- Bumped version to 0.2.3 in pyproject.toml for new PyPI release
- Ensured MIT license metadata and LICENSE file are present and correct
- README and packaging now accurately reflect the current feature set and compliance for PyPI upload